### PR TITLE
Update key-bindings.bash

### DIFF
--- a/shell/key-bindings.bash
+++ b/shell/key-bindings.bash
@@ -65,7 +65,7 @@ if [ -n "$TMUX_PANE" ]; then
   [ $BASH_VERSINFO -gt 3 ] && __use_tmux_auto=1
 fi
 
-if [ -z "$(set -o | \grep '^vi.*on')" ]; then
+if [[ $'\n'$(set -o) != *$'\n'vi*on* ]]; then
   # Required to refresh the prompt after fzf
   bind '"\er": redraw-current-line'
   bind '"\e^": history-expand-line'


### PR DESCRIPTION
Faster startup. Use internal bash globbing instead of external grep binary (adapter from Gentoo's `/etc/bash/bashrc` TERM checking). Insignificant on Linux, but on Cygwin this cuts startup time by 40 ms on my Core i7 laptop.
